### PR TITLE
Use pikadays built in date format

### DIFF
--- a/pikaday-directive.js
+++ b/pikaday-directive.js
@@ -21,7 +21,7 @@ angular.module('pikaday', [])
 
             options.onSelect = function(date) {
                 $scope.date = this.toString();
-                $scope.$apply($scope.date);
+                $scope.$apply();
 
                 if (angular.isFunction(onSelect)) {
                     onSelect();


### PR DESCRIPTION
Changed `$scope.date = date;` to `$scope.date = this.toString();` which enables setting the Pikaday format in the options object and having the date output based on that format.
