### PR TITLE
Update pikaday dependency to 1.2.0

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "angular-pikaday-directive",
-  "version": "0.0.1",
+  "version": "0.0.1.1",
   "authors": [
     "Sebastian Slomski <me@sebslomski.com>"
   ],
@@ -14,6 +14,6 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "pikaday": "~1.1.0"
+    "pikaday": "~1.2.0"
   }
 }


### PR DESCRIPTION
Yesterday I faced an issue with pikaday versions conflict while ran `bower install`

```
Unable to find a suitable version for pikaday, please choose one:
    1) pikaday#~1.1.0 which resolved to 1.1.0 and is required by angular-pikaday-directive#0.0.1
    2) pikaday#1.2.0 which resolved to 1.2.0 and is required by clientPrefix the choice with ! to persist it to bower.json

? Answer::
```

To resolve it I had to fork your repository and set it in `bower.json`

```
    "angular-pikaday-directive": "git@github.com:kont-noor/angular-pikaday-directive.git#23d2e6f"
```

Also I found a number of similar issues in the Internet so sinse your repository is default I propose you to merge changes I made.
